### PR TITLE
chore(cz, deepsource, workflows): environment configuration

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -23,7 +23,7 @@ jobs:
             BRANCH_NAME=${GITHUB_REF##*/}
           fi
           
-          if [[ ! "$BRANCH_NAME" =~ ^(docs|feature|bugfix|hotfix|release|chore|refactor)/[a-z0-9]+(-[a-z0-9]+)* ]]; then
+          if [[ ! "$BRANCH_NAME" =~ ^(docs|feature|bugfix|hotfix|release|chore|refactor)/[a-z0-9]+(-[a-z0-9]+)*$ && "$BRANCH_NAME" != "main" ]]; then
             echo "Invalid branch name: $BRANCH_NAME"
             echo "Branch names must start with: 'docs|feature|bugfix|hotfix|release|chore|refactor'/"
             exit 1


### PR DESCRIPTION
# chore(cz, deepsource, workflows): environment configuration
--

## What? ✌️

The following tools have been configured in the project:

- [Commitizen](https://commitizen-tools.github.io/commitizen/),
- [DeepSource](https://deepsource.com/),
- .gitignore,
- pom.xml,
- [README.md](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax),
- PULL_REQUEST_TEMPLATE.md --> [1](https://contribute.freecodecamp.org/how-to-open-a-pull-request/) [2](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/),
- [JaCoCo](https://www.baeldung.com/jacoco),
- workflows:
  - first.yml ---> This workflow is responsible for test running script
  - first-secret.yml ---> This workflow is responsible for test running script with secret
  - bumpversion.yml ---> This workflow is responsible for automatically incrementing the application version and generating a changelog with each push to the master branch
  - deepsource.yml ---> This workflow includes steps to check the code, run tests, generate coverage reports, and analyze the code using DeepSource.
  -  branch-name-check.yml ---> This workflow is responsible for imposing a pattern for the branch name (include main)

## What Implement successful? 🤔

- [x] .cz.yaml
- [x] .deepsource.toml
- [x] .gitignore
- [x] pom.xml
- [x] README.md
- [x] PULL_REQUEST_TEMPLATE.md
- [x] \workflows\first.yml
- [x] \workflows\first-secret.yml
- [x] \workflows\deepsource.yml
- [x] \workflows\bumpversion.yml
- [x] \workflows\ranch-name-check.yml

issue: -